### PR TITLE
fix(LiveTroopExercise): 挑战失败的处理

### DIFF
--- a/assets/resource/base/pipeline/tasks/deprecated/LiveTroopExercises.json
+++ b/assets/resource/base/pipeline/tasks/deprecated/LiveTroopExercises.json
@@ -51,6 +51,7 @@
         "post_wait_freezes": 500,
         "next": [
             "challengeSuccess",
+            "challengeFail",
             "combatValueRecognition",
             "refreshData"
         ]
@@ -58,6 +59,20 @@
     "challengeSuccess": {
         "recognition": "OCR",
         "expected": "挑战成功",
+        "target": [
+            1164,
+            656,
+            45,
+            26
+        ],
+        "post_delay": 1500,
+        "next": [
+            "refreshData"
+        ]
+    },
+    "challengeFail": {
+        "recognition": "OCR",
+        "expected": "挑战失败",
         "target": [
             1164,
             656,


### PR DESCRIPTION
参考挑战成功,添加了挑战失败后刷新的操作.
(模拟器卡死/掉线后挑战失败)