### PR TITLE
chore: 下载本地构建用的依赖

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -443,6 +443,7 @@ enc_temp_folder/*
 deps
 build
 install
+MFA
 
 # Tools
 tools/ImageCropper/**/*.png

--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@
 
 
 ## 开发相关
+### 本地构建方式
+1. 使用 `git clone --recurse-submodules https://github.com/xxx/xxx.git` 克隆仓库，确保包含了子模块
+2. 使用 `pip install -r requirements.txt` 安装依赖
+3. 使用 `python scripts\download_deps.py` 下载依赖
+4. 执行 `python install.py v0.0.0`
+5. 把 `MFA/MFAWPF.exe` 复制到 `install` 文件夹中，并改名为 `MaaGF2Exilium.exe`
+6. 执行 `jq --arg url "https://github.com/xxx/xxx" --arg version "v0.0.0" '. + {"url": $url, "version": $version}' ./assets/interface.json > ./install/interface.json`
+7. 现在构建好的文件夹就是 `install`
+
+
 ### 致谢
 
 - [MaaFramework](https://github.com/MaaXYZ/MaaFramework) 自动化测试框架

--- a/install.py
+++ b/install.py
@@ -14,8 +14,8 @@ version = len(sys.argv) > 1 and sys.argv[1] or "v0.0.1"
 
 def install_deps():
     if not (working_dir / "deps" / "bin").exists():
-        print("Please download the MaaFramework to \"deps\" first.")
-        print("请先下载 MaaFramework 到 \"deps\"。")
+        print('Please download the MaaFramework to "deps" first.')
+        print('请先下载 MaaFramework 到 "deps"。')
         sys.exit(1)
 
     shutil.copytree(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+black==24.10.0
+certifi==2024.12.14
+charset-normalizer==3.4.1
+click==8.1.8
+colorama==0.4.6
+idna==3.10
+mypy-extensions==1.0.0
+packaging==24.2
+pathspec==0.12.1
+platformdirs==4.3.6
+requests==2.32.3
+setuptools==75.1.0
+tqdm==4.67.1
+urllib3==2.3.0
+wheel==0.44.0

--- a/scripts/download_deps.py
+++ b/scripts/download_deps.py
@@ -1,0 +1,157 @@
+import os
+import requests
+import os
+import zipfile
+import re
+import platform
+from tqdm import tqdm
+
+
+def get_architecture():
+    arch = platform.machine().lower()
+    arch_mapping = {
+        "amd64": "x86_64",
+        "x86_64": "x86_64",
+        "aarch64": "aarch64",
+        "arm64": "aarch64",
+    }
+    return arch_mapping.get(arch, arch)
+
+
+def download_maa_framework(output_path="deps"):
+    """
+    下载 MaaFramework 的最新版本
+
+    参数:
+    output_path: 输出目录
+    """
+    # 创建输出目录
+    os.makedirs(output_path, exist_ok=True)
+
+    # GitHub API 地址
+    api_url = "https://api.github.com/repos/MaaXYZ/MaaFramework/releases/latest"
+
+    try:
+        # 获取最新版本信息
+        response = requests.get(api_url)
+        response.raise_for_status()
+        release_data = response.json()
+
+        # 查找匹配的资源文件
+        pattern = f"MAA-win-x86_64"
+        matching_assets = [
+            asset for asset in release_data["assets"] if pattern in asset["name"]
+        ]
+
+        if not matching_assets:
+            raise Exception(f"No matching assets found for: MAA-win-x86_64")
+
+        asset = matching_assets[0]
+        download_url = asset["browser_download_url"]
+        filename = asset["name"]
+        file_size = asset["size"]
+
+        # 下载文件
+        response = requests.get(download_url, stream=True)
+        response.raise_for_status()
+
+        file_path = os.path.join(output_path, filename)
+        with open(file_path, "wb") as f:
+            with tqdm(
+                total=file_size,
+                unit="iB",
+                unit_scale=True,
+                unit_divisor=1024,
+                desc=filename,
+            ) as pbar:
+                for chunk in response.iter_content(chunk_size=8192):
+                    size = f.write(chunk)
+                    pbar.update(size)
+
+        # 解压文件，然后删除压缩包
+        with zipfile.ZipFile(file_path, "r") as zip_ref:
+            file_list = zip_ref.namelist()
+            with tqdm(total=len(file_list), desc="Extracting", unit="files") as pbar:
+                for file in file_list:
+                    zip_ref.extract(file, output_path)
+                    pbar.update(1)
+        os.remove(file_path)
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error downloading file: {e}")
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+def download_mfa_wpf(output_path="MFA"):
+    """
+    下载 MFAWPF的最新版本
+
+    参数:
+    output_path: 输出目录
+    """
+    # 创建输出目录
+    os.makedirs(output_path, exist_ok=True)
+
+    # GitHub API 地址
+    api_url = "https://api.github.com/repos/SweetSmellFox/MFAWPF/releases/latest"
+
+    try:
+        # 获取最新版本信息
+        response = requests.get(api_url)
+        response.raise_for_status()
+        release_data = response.json()
+
+        # 查找匹配的资源文件
+        pattern = f"MFAWPF"
+        matching_assets = [
+            asset for asset in release_data["assets"] if pattern in asset["name"]
+        ]
+
+        if not matching_assets:
+            raise Exception(f"No matching assets found for: MFAWPF")
+
+        asset = matching_assets[0]
+        download_url = asset["browser_download_url"]
+        filename = asset["name"]
+        file_size = asset["size"]
+
+        # 下载文件
+        response = requests.get(download_url, stream=True)
+        response.raise_for_status()
+
+        file_path = os.path.join(output_path, filename)
+        with open(file_path, "wb") as f:
+            with tqdm(
+                total=file_size,
+                unit="iB",
+                unit_scale=True,
+                unit_divisor=1024,
+                desc=filename,
+            ) as pbar:
+                for chunk in response.iter_content(chunk_size=8192):
+                    size = f.write(chunk)
+                    pbar.update(size)
+
+        # 解压文件，然后删除压缩包
+        with zipfile.ZipFile(file_path, "r") as zip_ref:
+            file_list = zip_ref.namelist()
+            with tqdm(total=len(file_list), desc="Extracting", unit="files") as pbar:
+                for file in file_list:
+                    zip_ref.extract(file, output_path)
+                    pbar.update(1)
+        os.remove(file_path)
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error downloading file: {e}")
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    arch = get_architecture()
+    if os.name == "nt" and arch == "x86_64":
+        download_maa_framework()
+        download_mfa_wpf()
+    else:
+        print("当前系统不是 x86_64 的 Windows 系统，请等待后续开发")


### PR DESCRIPTION
从 github actions 里扒了一下构建流程，在文档里写出来，方便后面还有别人要开发的话直接使用

目前只有下载依赖这个事比较麻烦，所以专门写了个脚本处理，别的已经有的流程就没动，后续或许可以考虑把构建流程全部放到一个 py 文件里？不然还要手动输入好几个命令太麻烦了

#12 之前说的仓库相关的功能，春节期间我没空做了，最近有点太忙了，你要是不急的话我就节后做