### PR TITLE
fix: 增加邮件后到整理仓库的入口

### DIFF
--- a/assets/resource/pipeline/public/PrepareDailyTasks/Email/getNewEmails.json
+++ b/assets/resource/pipeline/public/PrepareDailyTasks/Email/getNewEmails.json
@@ -9,6 +9,7 @@
             "staminaReplenishment",
             "enterGameStoreAction",
             "enterBoundaryAdvanceAction",
+            "organizeWarehouse",
             "HomePage"
         ]
     },
@@ -58,6 +59,7 @@
             "staminaReplenishment",
             "enterGameStoreAction",
             "enterBoundaryAdvanceAction",
+            "organizeWarehouse",
             "HomePage"
         ]
     },


### PR DESCRIPTION
在写邮件相关功能的时候发现了一个入口漏写了

虽然漏写了，但是考虑到前面还有别的一堆 next 节点，这个 bug 的存在其实也不太会影响功能（应该没有用户会把前面一堆节点关掉吧），所以我就先不自己合并了，等你 review 一下