### PR TITLE
fix: 体力兑换默认不执行

### DIFF
--- a/assets/resource/pipeline/public/PrepareDailyTasks/StaminaReplenishments/staminaReplenishment.json
+++ b/assets/resource/pipeline/public/PrepareDailyTasks/StaminaReplenishments/staminaReplenishment.json
@@ -1,7 +1,7 @@
 {
     "staminaReplenishment": {
         "doc": "用光全部体力",
-        "enabled": true,
+        "enabled": false,
         "recognition": "OCR",
         "expected": "战役推进",
         "target": [


### PR DESCRIPTION
在用 maadebugger 测试的时候，体力兑换默认是 true，每次去调很麻烦，如果忘了调就会多花体力药

不影响实际功能，interface 里 override 了