### PR TITLE
fix: 默认配件类型改为异位打击

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -688,6 +688,14 @@
         "配件效果：": {
             "cases": [
                 {
+                    "name": "异位打击",
+                    "pipeline_override": {
+                        "selectedEffectsCombination": {
+                            "expected": "^异位打击$"
+                        }
+                    }
+                },
+                {
                     "name": "制胜追进",
                     "pipeline_override": {
                         "selectedEffectsCombination": {
@@ -700,14 +708,6 @@
                     "pipeline_override": {
                         "selectedEffectsCombination": {
                             "expected": "^双重对策$"
-                        }
-                    }
-                },
-                {
-                    "name": "异位打击",
-                    "pipeline_override": {
-                        "selectedEffectsCombination": {
-                            "expected": "^异位打击$"
                         }
                     }
                 },

--- a/assets/resource/pipeline/tasks/AutoSweepBattle.json
+++ b/assets/resource/pipeline/tasks/AutoSweepBattle.json
@@ -303,7 +303,7 @@
             336,
             340
         ],
-        "expected": "^实弹增幅$",
+        "expected": "^异位打击$",
         "action": "Click",
         "next": [
             "selectedEffectsCombinationNextButtonClick"


### PR DESCRIPTION
默认类型改为了异位打击，保证在使用 maabugger 和 GUI 上没做设置的情况下，也能获得最通用的配件