### PR TITLE
refactor: 调整部分描述为外服官方翻译

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -126,7 +126,7 @@
         },
         {
             "name": "模拟作战日常",
-            "entry": "SimulatedCombat",
+            "entry": "CombatSimulations",
             "option": [
                 "首领挑战自律",
                 "自动实兵演习",
@@ -1145,7 +1145,7 @@
                 {
                     "name": "YES",
                     "pipeline_override": {
-                        "enterBossChallengeTask": {
+                        "enterBossFightTask": {
                             "enabled": true
                         }
                     }
@@ -1153,7 +1153,7 @@
                 {
                     "name": "NO",
                     "pipeline_override": {
-                        "enterBossChallengeTask": {
+                        "enterBossFightTask": {
                             "enabled": false
                         }
                     }
@@ -1165,7 +1165,7 @@
                 {
                     "name": "YES",
                     "pipeline_override": {
-                        "enterLiveDrillTask": {
+                        "enterCombatExercise": {
                             "enabled": true
                         }
                     }
@@ -1173,7 +1173,7 @@
                 {
                     "name": "NO",
                     "pipeline_override": {
-                        "enterLiveDrillTask": {
+                        "enterCombatExercise": {
                             "enabled": false
                         }
                     }
@@ -1185,7 +1185,7 @@
                 {
                     "name": "x1",
                     "pipeline_override": {
-                        "insufficientPermissionsForLiveDrill": {
+                        "insufficientPassesForCombatExercise": {
                             "expected": "2/3"
                         }
                     }
@@ -1193,7 +1193,7 @@
                 {
                     "name": "x2",
                     "pipeline_override": {
-                        "insufficientPermissionsForLiveDrill": {
+                        "insufficientPassesForCombatExercise": {
                             "expected": "1/3"
                         }
                     }
@@ -1201,7 +1201,7 @@
                 {
                     "name": "x3",
                     "pipeline_override": {
-                        "insufficientPermissionsForLiveDrill": {
+                        "insufficientPassesForCombatExercise": {
                             "expected": "0/3"
                         }
                     }
@@ -1241,7 +1241,7 @@
                 {
                     "name": "YES",
                     "pipeline_override": {
-                        "enterWarGameSimulationTask": {
+                        "enterMilitarySimulationTask": {
                             "enabled": true
                         }
                     }
@@ -1249,7 +1249,7 @@
                 {
                     "name": "NO",
                     "pipeline_override": {
-                        "enterWarGameSimulationTask": {
+                        "enterMilitarySimulationTask": {
                             "enabled": false
                         }
                     }

--- a/assets/resource/pipeline/public/SimulatedCombat/bossChallenge.json
+++ b/assets/resource/pipeline/public/SimulatedCombat/bossChallenge.json
@@ -1,29 +1,29 @@
 {
-    "enterBossChallengeTask": {
+    "enterBossFightTask": {
         "next": [
-            "clickEnterBossChallengePage"
+            "clickEnterBossFightPage"
         ]
     },
-    "clickEnterBossChallengePage": {
+    "clickEnterBossFightPage": {
         "recognition": "OCR",
         "expected": "^首领挑战$",
         "action": "Click",
         "post_wait_freezes": 300,
         "next": [
-            "enterBossRoutineChallenge"
+            "enterBossStandardBattle"
         ]
     },
-    "enterBossRoutineChallenge": {
+    "enterBossStandardBattle": {
         "recognition": "OCR",
         "expected": "^常规挑战$",
         "action": "Click",
         "post_wait_freezes": 300,
         "next": [
-            "insufficientPermissionsForBossChallenge",
-            "clickBossChallengeAutonomyButton"
+            "insufficientAccessForBossFight",
+            "clickBossFightAutoButton"
         ]
     },
-    "insufficientPermissionsForBossChallenge": {
+    "insufficientAccessForBossFight": {
         "doc": "首领挑战权限不足",
         "recognition": "OCR",
         "expected": "0/1$",
@@ -34,10 +34,10 @@
             54
         ],
         "next": [
-            "exitBossChallenge"
+            "exitBossFight"
         ]
     },
-    "exitBossChallenge": {
+    "exitBossFight": {
         "recognition": "TemplateMatch",
         "roi": [
             0,
@@ -51,20 +51,20 @@
         ],
         "action": "Click",
         "next": [
-            "enterLiveDrillTask",
-            "enterWarGameSimulationTask",
+            "enterCombatExercise",
+            "enterMilitarySimulationTask",
             "returnToHomePage"
         ]
     },
-    "clickBossChallengeAutonomyButton": {
+    "clickBossFightAutoButton": {
         "recognition": "OCR",
         "expected": "^自律$",
         "action": "Click",
         "next": [
-            "increaseSelfDisciplineCountForBossChallenge"
+            "increaseAutoBattleCountForBossFight"
         ]
     },
-    "increaseSelfDisciplineCountForBossChallenge": {
+    "increaseAutoBattleCountForBossFight": {
         "doc": "增加自律次数",
         "recognition": "TemplateMatch",
         "roi": [
@@ -80,11 +80,11 @@
         "post_delay": 100,
         "action": "Click",
         "next": [
-            "maxSelfDisciplineCountForBossChallenge",
-            "increaseSelfDisciplineCountForBossChallenge"
+            "maxAutoBattleCountForBossFight",
+            "increaseAutoBattleCountForBossFight"
         ]
     },
-    "maxSelfDisciplineCountForBossChallenge": {
+    "maxAutoBattleCountForBossFight": {
         "doc": "首领挑战自律次数达到最大值",
         "recognition": "ColorMatch",
         "roi": [
@@ -105,10 +105,10 @@
         ],
         "post_delay": 100,
         "next": [
-            "confirmBossChallengeSelfDiscipline"
+            "confirmBossFightSelfDiscipline"
         ]
     },
-    "confirmBossChallengeSelfDiscipline": {
+    "confirmBossFightSelfDiscipline": {
         "doc": "确认进行BOSS挑战自律",
         "roi": [
             260,
@@ -121,17 +121,17 @@
         "action": "Click",
         "post_wait_freezes": 300,
         "next": [
-            "closeBossChallengeResultsPage"
+            "closeBossFightResultsPage"
         ]
     },
-    "closeBossChallengeResultsPage": {
+    "closeBossFightResultsPage": {
         "doc": "关闭心智勘测结果页",
         "recognition": "OCR",
         "expected": "点击空白处关闭",
         "action": "Click",
         "next": [
-            "closeBossChallengeResultsPage",
-            "insufficientPermissionsForBossChallenge"
+            "closeBossFightResultsPage",
+            "insufficientAccessForBossFight"
         ]
     }
 }

--- a/assets/resource/pipeline/public/SimulatedCombat/liveDrill.json
+++ b/assets/resource/pipeline/public/SimulatedCombat/liveDrill.json
@@ -1,21 +1,21 @@
 {
-    "enterLiveDrillTask": {
+    "enterCombatExercise": {
         "next": [
-            "clickEnterLiveDrillPage"
+            "clickEnterCombatExercisePage"
         ]
     },
-    "clickEnterLiveDrillPage": {
+    "clickEnterCombatExercisePage": {
         "recognition": "OCR",
         "expected": "实兵演习",
         "action": "Click",
         "post_delay": 2500,
         "next": [
-            "liveTroopExerciseWeeklySettlement",
-            "insufficientPermissionsForLiveDrill",
+            "combatExerciseWeeklySettlement",
+            "insufficientPassesForCombatExercise",
             "clickButtonToEnterOpponentSelection"
         ]
     },
-    "liveTroopExerciseWeeklySettlement": {
+    "combatExerciseWeeklySettlement": {
         "doc": "实兵演习每周结算",
         "recognition": "OCR",
         "expected": [
@@ -26,7 +26,7 @@
         "action": "Click",
         "post_delay": 2500,
         "next": [
-            "liveTroopExerciseWeeklySettlement",
+            "combatExerciseWeeklySettlement",
             "clickButtonToEnterOpponentSelection"
         ]
     },
@@ -37,11 +37,11 @@
         "action": "Click",
         "post_wait_freezes": 500,
         "next": [
-            "confirmLiveDrillOpponentListPage",
-            "liveTroopExerciseWeeklySettlement"
+            "confirmCombatExerciseOpponentListPage",
+            "combatExerciseWeeklySettlement"
         ]
     },
-    "confirmLiveDrillOpponentListPage": {
+    "confirmCombatExerciseOpponentListPage": {
         "doc": "确认实兵演习对象列表页",
         "recognition": "OCR",
         "roi": [
@@ -55,7 +55,7 @@
             "当前积分"
         ],
         "next": [
-            "insufficientPermissionsForLiveDrill",
+            "insufficientPassesForCombatExercise",
             "hasChallengeSuccessfulObject",
             "challengeOpponentSelection",
             "refreshOpponentList"
@@ -137,10 +137,10 @@
         "expected": "资源加载中",
         "next": [
             "enterLiveDrillCombatResourceLoading",
-            "clickLiveDrillStartCombatButton"
+            "clickCombatExerciseStartCombatButton"
         ]
     },
-    "insufficientPermissionsForLiveDrill": {
+    "insufficientPassesForCombatExercise": {
         "doc": "实兵演习权限不足(不足有两种页面：实兵演习首页，挑战对象选择页)",
         "recognition": "OCR",
         "expected": "0/3",
@@ -152,7 +152,7 @@
         ],
         "next": [
             "exitChallengeOpponentSelection",
-            "exitLiveDrillPage"
+            "exitCombatExercisePage"
         ]
     },
     "exitChallengeOpponentSelection": {
@@ -177,11 +177,11 @@
         ],
         "action": "Click",
         "next": [
-            "claimLiveDrillRewards",
-            "exitLiveDrillPage"
+            "claimCombatExerciseRewards",
+            "exitCombatExercisePage"
         ]
     },
-    "claimLiveDrillRewards": {
+    "claimCombatExerciseRewards": {
         "doc": "领取实兵演习奖励，要求演习进度为满",
         "recognition": "TemplateMatch",
         "roi": [
@@ -193,22 +193,22 @@
         "template": "实兵演习/演习补给待领取.png",
         "action": "Click",
         "next": [
-            "claimLiveDrillRewards",
-            "closeLiveDrillRewardClaimResultPage"
+            "claimCombatExerciseRewards",
+            "closeCombatExerciseRewardClaimResultPage"
         ]
     },
-    "closeLiveDrillRewardClaimResultPage": {
+    "closeCombatExerciseRewardClaimResultPage": {
         "doc": "关闭实兵演习奖励领取结果页(由于识别太快可能点击无效果，需要调用自身)",
         "recognition": "OCR",
         "expected": "点击空白处关闭",
         "action": "Click",
         "next": [
-            "liveDrillRewardProgressNotMet",
-            "closeLiveDrillRewardClaimResultPage",
-            "exitLiveDrillPage"
+            "combatExerciseRewardProgressNotMet",
+            "closeCombatExerciseRewardClaimResultPage",
+            "exitCombatExercisePage"
         ]
     },
-    "liveDrillRewardProgressNotMet": {
+    "combatExerciseRewardProgressNotMet": {
         "doc": "实兵演习奖励进度未满",
         "recognition": "TemplateMatch",
         "roi": [
@@ -219,10 +219,10 @@
         ],
         "template": "实兵演习/演习补给已领取.png",
         "next": [
-            "exitLiveDrillPage"
+            "exitCombatExercisePage"
         ]
     },
-    "exitLiveDrillPage": {
+    "exitCombatExercisePage": {
         "doc": "实兵演习页返回",
         "recognition": "OCR",
         "expected": "演习记录",
@@ -234,7 +234,7 @@
         ],
         "action": "Click",
         "next": [
-            "enterWarGameSimulationTask",
+            "enterMilitarySimulationTask",
             "returnToHomePage"
         ]
     }

--- a/assets/resource/pipeline/public/SimulatedCombat/liveDrillCombatLogic.json
+++ b/assets/resource/pipeline/public/SimulatedCombat/liveDrillCombatLogic.json
@@ -1,5 +1,5 @@
 {
-    "clickLiveDrillStartCombatButton": {
+    "clickCombatExerciseStartCombatButton": {
         "doc": "点击实兵演习战斗开始按钮",
         "recognition": "OCR",
         "expected": "作战开始",
@@ -12,10 +12,10 @@
         "action": "Click",
         "next": [
             "ableToChangeSpeed",
-            "clickLiveDrillStartCombatButton"
+            "clickCombatExerciseStartCombatButton"
         ]
     },
-    "enableLiveDrillAutoCombat": {
+    "enableCombatExerciseAutoCombat": {
         "doc": "点击实兵演习自动战斗按钮",
         "recognition": "ColorMatch",
         "connected": true,
@@ -38,7 +38,7 @@
         ],
         "action": "Click",
         "next": [
-            "waitingForLiveDrillAutoCombatToEnd"
+            "waitingForCombatExerciseAutoCombatToEnd"
         ]
     },
     "ableToChangeSpeed": {
@@ -107,7 +107,7 @@
         ],
         "threshold": 0.9,
         "next": [
-            "enableLiveDrillAutoCombat"
+            "enableCombatExerciseAutoCombat"
         ]
     },
     "clickChangeSpeedButtonTo2xSpeed": {
@@ -138,18 +138,18 @@
             "clickChangeSpeedButtonTo3xSpeed"
         ]
     },
-    "waitingForLiveDrillAutoCombatToEnd": {
+    "waitingForCombatExerciseAutoCombatToEnd": {
         "doc": "等待实兵演习自动战斗结束",
         "post_wait_freezes": {
             "time": 2500,
             "threshold": 0.8
         },
         "next": [
-            "liveDrillTaskCompleted",
-            "waitingForLiveDrillAutoCombatToEnd"
+            "combatExerciseTaskCompleted",
+            "waitingForCombatExerciseAutoCombatToEnd"
         ]
     },
-    "liveDrillTaskCompleted": {
+    "combatExerciseTaskCompleted": {
         "doc": "实兵演习任务完成或失败",
         "recognition": "OCR",
         "expected": [
@@ -159,11 +159,11 @@
         "action": "Click",
         "post_wait_freezes": 300,
         "next": [
-            "confirmLevelPromotionForLiveDrill",
-            "clickConfirmButtonToExitLiveDrill"
+            "confirmLevelPromotionForCombatExercise",
+            "clickConfirmButtonToExitCombatExercise"
         ]
     },
-    "confirmLevelPromotionForLiveDrill": {
+    "confirmLevelPromotionForCombatExercise": {
         "doc": "确认实兵演习等级晋级",
         "recognition": "OCR",
         "expected": [
@@ -173,18 +173,18 @@
         ],
         "action": "Click",
         "next": [
-            "confirmLevelPromotionForLiveDrill",
-            "confirmLiveDrillOpponentListPage",
-            "clickConfirmButtonToExitLiveDrill"
+            "confirmLevelPromotionForCombatExercise",
+            "confirmCombatExerciseOpponentListPage",
+            "clickConfirmButtonToExitCombatExercise"
         ]
     },
-    "clickConfirmButtonToExitLiveDrill": {
+    "clickConfirmButtonToExitCombatExercise": {
         "recognition": "OCR",
         "expected": "确认",
         "action": "Click",
         "next": [
-            "clickConfirmButtonToExitLiveDrill",
-            "confirmLevelPromotionForLiveDrill",
+            "clickConfirmButtonToExitCombatExercise",
+            "confirmLevelPromotionForCombatExercise",
             "exitLiveDrillCombatResourceLoading"
         ]
     },
@@ -194,8 +194,8 @@
         "expected": "资源加载中",
         "next": [
             "exitLiveDrillCombatResourceLoading",
-            "confirmLevelPromotionForLiveDrill",
-            "confirmLiveDrillOpponentListPage"
+            "confirmLevelPromotionForCombatExercise",
+            "confirmCombatExerciseOpponentListPage"
         ]
     }
 }

--- a/assets/resource/pipeline/public/SimulatedCombat/wargameSimulation.json
+++ b/assets/resource/pipeline/public/SimulatedCombat/wargameSimulation.json
@@ -1,5 +1,5 @@
 {
-    "enterWarGameSimulationTask": {
+    "enterMilitarySimulationTask": {
         "action": "Swipe",
         "begin": [
             1124,
@@ -15,11 +15,11 @@
         ],
         "post_delay": 1000,
         "next": [
-            "clickEnterWarGameSimulationPage",
-            "enterWarGameSimulationTask"
+            "clickEnterMilitarySimulationPage",
+            "enterMilitarySimulationTask"
         ]
     },
-    "clickEnterWarGameSimulationPage": {
+    "clickEnterMilitarySimulationPage": {
         "doc": "点击进入兵棋推演界面",
         "recognition": "OCR",
         "expected": "兵棋推演",

--- a/assets/resource/pipeline/tasks/SimulatedCombat.json
+++ b/assets/resource/pipeline/tasks/SimulatedCombat.json
@@ -1,31 +1,31 @@
 {
-    "SimulatedCombat": {
+    "CombatSimulations": {
         "doc": "模拟作战日常",
         "next": [
-            "enterSimulatedCombatTask"
+            "enterCombatSimulationsTask"
         ],
         "interrupt": [
             "StartGame"
         ]
     },
-    "enterSimulatedCombatTask": {
+    "enterCombatSimulationsTask": {
         "doc": "正式进入模拟作战日常任务",
         "recognition": "OCR",
         "expected": "^战役推进$",
         "action": "Click",
         "post_wait_freezes": 100,
         "next": [
-            "clickEnterSimulatedCombatPage"
+            "clickEnterCombatSimulationsPage"
         ]
     },
-    "clickEnterSimulatedCombatPage": {
+    "clickEnterCombatSimulationsPage": {
         "recognition": "OCR",
         "expected": "^模拟作战$",
         "action": "Click",
         "next": [
-            "enterBossChallengeTask",
-            "enterLiveDrillTask",
-            "enterWarGameSimulationTask",
+            "enterBossFightTask",
+            "enterCombatExercise",
+            "enterMilitarySimulationTask",
             "returnToHomePage"
         ]
     }


### PR DESCRIPTION
正准备做峰值推定的内容，就顺便把同一个目录下的翻译先调整了

文件名都没动，减少用户更新的操作，等 mfawpf 的更新逻辑调整后再说

关于兵棋推演，外服测试号暂时等级不够进不去，只调整了入口的翻译，里面的以后再看
