### PR TITLE
feat(邮件处理): 在获取新邮件的配置中添加阈值设置

### DIFF
--- a/assets/resource/pipeline/public/PrepareDailyTasks/Email/getNewEmails.json
+++ b/assets/resource/pipeline/public/PrepareDailyTasks/Email/getNewEmails.json
@@ -25,6 +25,7 @@
             "公用按钮组件/邮件_主页.png",
             "公用按钮组件/邮件_主页_2.png"
         ],
+        "threshold": 0.75,
         "action": "Click",
         "next": [
             "claimAllEmails"


### PR DESCRIPTION
略微提高了识别的阈值，错误的识别也会有 0.71 的 `score`，导致一直卡在主页

但是正确的图标的 `score` 也就 0.78，真的有点无语了，沟槽的小黄的主页重置 bug，不知道修了没有，要是修了并且这次 `threshold` 调整还是不行，那还要改回原版