### PR TITLE
fix(顶级生长数据随机箱): 确保选中顶级花箱子

### DIFF
--- a/assets/resource/pipeline/public/PrepareDailyTasks/Storeroom/itemBox.json
+++ b/assets/resource/pipeline/public/PrepareDailyTasks/Storeroom/itemBox.json
@@ -106,6 +106,7 @@
     "openFlowerBox": {
         "doc": "顶级生长数据随机箱",
         "recognition": "TemplateMatch",
+        "index": -1,
         "template": [
             "仓库/顶级生长数据随机箱.png"
         ],


### PR DESCRIPTION
把 TemplateMatch 的算法类型从 5 调成 1 3 会有很严重的识别问题，会爆几千个框出来

后来发现如果顶级箱子和非顶级箱子都在的时候，游戏内默认的排序是，紫箱子、金箱子，所以出现识别候选的时候，加了个 index 确保选中的水平排序的最后（右）的一个箱子

不过这个依赖游戏内的排序机制，万一将来又出什么奇怪的箱子就不行了，不过现在也不好测试，目前只有这个紫箱子和金箱子的情况下，还是能正常识别的