### PR TITLE
chore: 优化构建脚本

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -107,7 +107,6 @@ jobs:
         shell: bash
         run: |
           python ./install.py ${{ needs.meta.outputs.tag }}
-          cp ./MFA/MFAWPF.exe ./install/MaaGF2Exilium.exe
           jq --arg url "https://github.com/DarkLingYun/MaaGF2Exilium" --arg version "${{ needs.meta.outputs.tag }}" '. + {"url": $url, "version": $version}' ./assets/interface.json > ./install/interface.json
           
       - uses: actions/upload-artifact@v4

--- a/docs/开发相关.md
+++ b/docs/开发相关.md
@@ -3,11 +3,10 @@
 1. 使用 `git clone --recurse-submodules https://github.com/xxx/xxx.git` 克隆仓库，确保包含了子模块
 2. 使用 `pip install -r requirements.txt` 安装依赖
 3. 使用 `python scripts/download_deps.py` 下载依赖
-4. 执行 `python install.py v0.0.0`
-5. 把 `MFA/MFAWPF.exe` 复制到 `install` 文件夹中
-6. 执行 `jq --arg url "https://github.com/xxx/xxx" --arg version "v0.0.0" '. + {"url": $url, "version": $version}' ./assets/interface.json > ./install/interface.json`
-7. 现在构建好的文件夹就是 `install`
-8. 如果需要重新构建，请删掉整个 `install` 重新执行第四步及之后的步骤，目前不会自动覆盖
+4. 执行 `python install.py`
+5. 执行 `jq --arg url "https://github.com/xxx/xxx" --arg version "v0.0.0" '. + {"url": $url, "version": $version}' ./assets/interface.json > ./install/interface.json`
+6. 现在构建好的文件夹就是 `install`
+7. 如果需要重新构建，请重新执行第四步
 
 
 ## 测试账号

--- a/install.py
+++ b/install.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import shutil
 import sys
 import json
+import os
 
 from configure import configure_ocr_model
 
@@ -70,9 +71,24 @@ def install_chores():
     )
 
 
+def install_mfawpf():
+    mfa_exe_path = working_dir / "MFA" / "MFAWPF.exe"
+    install_exe_path = install_path / "MaaGF2Exilium.exe"
+
+    if mfa_exe_path.exists():
+        shutil.copy2(
+            mfa_exe_path,
+            install_exe_path,
+        )
+        print(f"Copied MFAWPF.exe to {install_exe_path}")
+    else:
+        print("Warning: MFA/MFAWPF.exe not found. Skipping copy operation.")
+
+
 if __name__ == "__main__":
     install_deps()
     install_resource()
     install_chores()
+    install_mfawpf()
 
     print(f"Install to {install_path} successfully.")

--- a/install.py
+++ b/install.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import shutil
 import sys
 import json
-import os
 
 from configure import configure_ocr_model
 
@@ -38,6 +37,11 @@ def install_deps():
 
 
 def install_resource():
+    # 手动清理资源目录，防止旧文件残留，节点变化导致的冲突
+    resource_dir_to_clean = install_path / "resource"
+    if resource_dir_to_clean.exists():
+        print(f"正在清理已存在的资源目录: {resource_dir_to_clean}")
+        shutil.rmtree(resource_dir_to_clean)
 
     configure_ocr_model()
 


### PR DESCRIPTION
1. 现在可以不用手动复制文件到 install 文件夹了，直接把这个功能也放到 python 脚本里了
2. 在构建前会删除整个资源文件夹，防止增加删除 json 文件，因为老的脚本是直接覆盖，但是不删除不同名的旧的，小概率会导致残留文件的冲突