### PR TITLE
chore: 精简 GitHub Actions 工作流，移除不必要的构建步骤和平台支持

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - "**"
     paths:
       - ".github/workflows/install.yml"
       - "assets/**"
@@ -114,106 +112,9 @@ jobs:
           name: MaaGF2ExiliumGUI-win-${{ matrix.arch }}
           path: "install"
 
-  ubuntu:
-    needs: meta
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [aarch64, x86_64]
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Download MaaFramework
-        uses: robinraju/release-downloader@v1
-        with:
-          repository: MaaXYZ/MaaFramework
-          fileName: "MAA-linux-${{ matrix.arch }}*"
-          latest: true
-          out-file-path: "deps"
-          extract: true
-
-      - name: Install
-        shell: bash
-        run: |
-          python ./install.py ${{ needs.meta.outputs.tag }}
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: MaaGF2Exilium-linux-${{ matrix.arch }}
-          path: "install"
-
-  macos:
-    needs: meta
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        arch: [aarch64, x86_64]
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Download MaaFramework
-        uses: robinraju/release-downloader@v1
-        with:
-          repository: MaaXYZ/MaaFramework
-          fileName: "MAA-macos-${{ matrix.arch }}*"
-          latest: true
-          out-file-path: "deps"
-          extract: true
-
-      - name: Install
-        shell: bash
-        run: |
-          python ./install.py ${{ needs.meta.outputs.tag }}
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: MaaGF2Exilium-macos-${{ matrix.arch }}
-          path: "install"
-
-  android:
-    needs: meta
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        arch: [aarch64, x86_64]
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Download MaaFramework
-        uses: robinraju/release-downloader@v1
-        with:
-          repository: MaaXYZ/MaaFramework
-          fileName: "MAA-android-${{ matrix.arch }}*"
-          latest: true
-          
-          out-file-path: "deps"
-          extract: true
-
-      - name: Install
-        shell: bash
-        run: |
-          python ./install.py ${{ needs.meta.outputs.tag }}
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: MaaGF2Exilium-android-${{ matrix.arch }}
-          path: "install"
-
   release:
     if: ${{ needs.meta.outputs.is_release == 'true' }}
-    needs: [meta, windows, ubuntu, macos, android]
+    needs: [meta, windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
起因是我最近检查了一下 github 账单，发现本仓库对于 github actions 的使用有点过度了

比如从我这里看，上个月都用到免费额度的 40% 了，所以优化了一下防止超过额度

![image](https://github.com/user-attachments/assets/046cdf28-91f1-41c2-9612-f377c85946a1)

主要做了两个修改：
1. 删除了创建分支的触发，这个完全没有必要
2. 删除了除 Windows 以外的构建，目前 maafw 不支持 macos 上的 playcover 调用，而且这个 GUI 也只支持 Windows，跨平台构建没啥意义，不谈没图形界面，用命令行都几乎没法用