### PR TITLE
fix: 在获取新邮件的配置中添加 post_wait_freezes 参数以优化等待时间

### DIFF
--- a/assets/resource/pipeline/public/PrepareDailyTasks/Email/getNewEmails.json
+++ b/assets/resource/pipeline/public/PrepareDailyTasks/Email/getNewEmails.json
@@ -37,6 +37,7 @@
         "recognition": "OCR",
         "expected": "领取全部",
         "action": "Click",
+        "post_wait_freezes": 500,
         "next": [
             "noUnclaimedItems",
             "closeClaimAllEmailsPopup",
@@ -47,6 +48,7 @@
         "rate_limit": 100,
         "recognition": "OCR",
         "expected": "无可领取物品",
+        "post_wait_freezes": 500,
         "next": [
             "noUnclaimedItems",
             "findSurveyEmail",
@@ -92,6 +94,7 @@
         "recognition": "OCR",
         "expected": "点击空白",
         "action": "Click",
+        "post_wait_freezes": 500,
         "next": [
             "closeClaimAllEmailsPopup",
             "findSurveyEmail",


### PR DESCRIPTION
增加了一下等待时间，不然调研邮件还没出来就识别到下一步动作了，会漏掉