### PR TITLE
fix: 在险境挖掘任务中添加阈值设置

### DIFF
--- a/assets/resource/pipeline/public/ClaimRewardTasks/dangerousExcavation.json
+++ b/assets/resource/pipeline/public/ClaimRewardTasks/dangerousExcavation.json
@@ -203,6 +203,7 @@
         "template": "公用按钮组件/提醒.png",
         "action": "Click",
         "roi": [396,83,862,628],
+        "threshold": 0.65,
         "post_delay": 500,
         "next": [
             "closeClaimLineRewardResultPage"


### PR DESCRIPTION
如果不降低 threshold，最右下角的奖励识别不出来，测过了