### PR TITLE
fix: 添加等待时间以确保领取助战人形奖励稳定性

### DIFF
--- a/assets/resource/pipeline/public/ClaimRewardTasks/supportDollRewards.json
+++ b/assets/resource/pipeline/public/ClaimRewardTasks/supportDollRewards.json
@@ -25,6 +25,7 @@
         "recognition": "TemplateMatch",
         "template": "个人信息/领取.png",
         "action": "Click",
+        "post_wait_freezes": 500,
         "next": [
             "closeClaimResult",
             "claimSupportDollRewards"
@@ -35,6 +36,7 @@
         "recognition": "OCR",
         "expected": "点击空白处关闭",
         "action": "Click",
+        "post_wait_freezes": 500,
         "next": [
             "claimResultClosed",
             "closeClaimResult"
@@ -55,6 +57,7 @@
             "公用按钮组件/主页按钮_black.png"
         ],
         "action": "Click",
+        "post_wait_freezes": 500,
         "next": [
             "personalInformationPageExited",
             "exitPersonalInformationPage"


### PR DESCRIPTION
我自己观察到很多时候会卡在助战领取这里，看日志是claimSupportDollRewards死循环了，但是没复现出来，所以先加几个延时再观察观察