### PR TITLE
fix: 美服/国际服版本活动变更、修复首领挑战进入失败

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -1689,6 +1689,28 @@
                     }
                 },
                 {
+                    "name": "溯回时光之隙(美服/国际服)",
+                    "pipeline_override": {
+                        "clickVersionActivityTagButton": {
+                            "expected": [
+                                "溯回时光之隙",
+                                "^溯回"
+                            ]
+                        },
+                        "switchVersionActivityChapter": {
+                            "enabled": true,
+                            "expected": [
+                                "纪念日礼赞"
+                            ]
+                        },
+                        "enterVersionActivityItemExchange": {
+                            "expected": [
+                                "时光小筑"
+                            ]
+                        }
+                    }
+                },
+                {
                     "name": "烟火重燃之时(已结束)",
                     "pipeline_override": {
                         "clickVersionActivityTagButton": {
@@ -1704,7 +1726,7 @@
                     }
                 },
                 {
-                    "name": "匿影而生(美服/国际服)",
+                    "name": "匿影而生(已结束)",
                     "pipeline_override": {
                         "clickVersionActivityTagButton": {
                             "expected": [

--- a/assets/resource/resource_en/pipeline/tasks/public/SimulatedCombat/bossChallenge.json
+++ b/assets/resource/resource_en/pipeline/tasks/public/SimulatedCombat/bossChallenge.json
@@ -1,0 +1,11 @@
+{
+
+    "clickEnterBossFightPage": {
+        "doc": "增加重试",
+        "post_wait_freezes": 500,
+        "next": [
+            "enterBossStandardBattle",
+            "clickEnterBossFightPage"
+        ]
+    }
+}


### PR DESCRIPTION
- 美服/国际服活动更新
- 首领挑战因加载或动画进入失败的修复