### PR TITLE
fix: 美服/国际服版本 公共区日常、版本活动商店修复

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -1817,7 +1817,7 @@
                     }
                 },
                 {
-                    "name": "沉没夜潮",
+                    "name": "沉没夜潮（美服/国际服）",
                     "pipeline_override": {
                         "clickVersionActivityTagButton": {
                             "expected": [
@@ -1838,7 +1838,7 @@
                     }
                 },
                 {
-                    "name": "心跳游乐园（美服/国际服）",
+                    "name": "心跳游乐园(已结束)",
                     "pipeline_override": {
                         "clickVersionActivityTagButton": {
                             "expected": [
@@ -1934,7 +1934,7 @@
                     }
                 },
                 {
-                    "name": "溯回时光之隙（上）(美服/国际服)(已结束)",
+                    "name": "溯回时光之隙（上）(已结束)",
                     "pipeline_override": {
                         "clickVersionActivityTagButton": {
                             "expected": [
@@ -1962,7 +1962,7 @@
                     }
                 },
                 {
-                    "name": "溯回时光之隙（下）(美服/国际服)(已结束)",
+                    "name": "溯回时光之隙（下）(已结束)",
                     "pipeline_override": {
                         "clickVersionActivityTagButton": {
                             "expected": [

--- a/assets/resource/base/pipeline/public/VersionActivity/enterVersionActivityItemExchange.json
+++ b/assets/resource/base/pipeline/public/VersionActivity/enterVersionActivityItemExchange.json
@@ -8,10 +8,9 @@
         ],
         "index": -1,
         "action": "Click",
-        "post_delay": 2000,
+        "post_wait_freezes": 2000,
         "next": [
             "selectExchangeType",
-            "itemOutOfStock",
             "selectExchangeItem",
             "enterVersionActivityItemExchange"
         ]
@@ -88,40 +87,6 @@
         ],
         "next": [
             "exitVersionActivityItemExchange"
-        ]
-    },
-    "itemOutOfStock": {
-        "doc": "对可能点到已售罄的商品进行处理",
-        "recognition": "OCR",
-        "expected": "^已售",
-        "roi": [
-            594,
-            542,
-            93,
-            47
-        ],
-        "next": [
-            "exitItemExchange"
-        ]
-    },
-    "exitItemExchange": {
-        "recognition": "TemplateMatch",
-        "template": [
-            "公用按钮组件/关闭按钮_gray.png",
-            "公用按钮组件/关闭按钮_black.png"
-        ],
-        "roi": [
-            1104,
-            107,
-            44,
-            42
-        ],
-        "action": "Click",
-        "post_delay": 2000,
-        "next": [
-            "exitItemExchange",
-            "selectExchangeType",
-            "selectExchangeItem"
         ]
     },
     "selectExchangeItemQuantity": {

--- a/assets/resource/base/pipeline/tasks/AutoSweepBattle.json
+++ b/assets/resource/base/pipeline/tasks/AutoSweepBattle.json
@@ -279,7 +279,7 @@
             256,
             14
         ],
-        "post_delay": 1000
+        "post_wait_freezes": 1500
     },
     "selectedEffectsCombination": {
         "doc": "选择效果组合",

--- a/assets/resource/resource_en/pipeline/tasks/public/PublicAreaDailyTasks/dispatchCenter.json
+++ b/assets/resource/resource_en/pipeline/tasks/public/PublicAreaDailyTasks/dispatchCenter.json
@@ -102,7 +102,7 @@
             0,
             0
         ],
-        "post_wait_freezes": 300,
+        "post_wait_freezes": 1000,
         "next": [
             "closeDispatchCenterDispatchCountRewardClaimResultPage",
             "claimDispatchCenterDispatchCountReward"


### PR DESCRIPTION
- 美服/国际服版本更新 沉没夜潮
- 公共区日常 领取每周派遣奖励稍加freeze等待
- 定向精研 滑动选择词条时使用post_wait_freezes，避免识别到滑动中的词条位置
- 版本活动商店 这个应该只要点进去商店的时候用post_wait_freezes就能避免再次点击点到已售罄的商品