### PR TITLE
fix: 增加循环助手超时时间以支持尘烟前线

### DIFF
--- a/assets/resource/base/pipeline/public/循环助手/循环助手.json
+++ b/assets/resource/base/pipeline/public/循环助手/循环助手.json
@@ -53,7 +53,7 @@
             "确认"
         ],
         "action": "Click",
-        "timeout": 600000,
+        "timeout": 6000000, // 有的用户会用循环助手打尘烟前线，需要设置时间长一点
         "order_by": "Horizontal",
         "index": -1,
         "post_wait_freezes": 500,


### PR DESCRIPTION
将超时时间从10分钟增加到100分钟，解决用户使用循环助手打尘烟前线时超时的问题