### PR TITLE
fix: 修复限时中型活动领取代币的OCR识别精确度

### DIFF
--- a/assets/resource/base/pipeline/public/ClaimRewardTasks/限时中型活动.json
+++ b/assets/resource/base/pipeline/public/ClaimRewardTasks/限时中型活动.json
@@ -99,7 +99,7 @@
     "领取代币-限时中型活动": {
         "recognition": "OCR",
         "expected": [
-            "领取"
+            "^领取$"
         ],
         "action": "Click",
         "post_wait_freezes": 500,


### PR DESCRIPTION
将领取改为^领取$正则匹配，避免误识别其他包含领取的文字