### PR TITLE
fix: 修复OCR将「下一步」识别为「下一」的问题

### DIFF
--- a/assets/resource/base/pipeline/public/ClaimRewardTasks/passSystem.json
+++ b/assets/resource/base/pipeline/public/ClaimRewardTasks/passSystem.json
@@ -160,7 +160,8 @@
         "recognition": "OCR",
         "expected": [
             "^开启$",
-            "^下一个$"
+            "^下一个$",
+            "^下一$"
         ],
         "action": "Click",
         "post_delay": 2000,

--- a/assets/resource/base/pipeline/public/活动层/美味烹调.json
+++ b/assets/resource/base/pipeline/public/活动层/美味烹调.json
@@ -105,7 +105,8 @@
     "邀请人形-美味烹调": {
         "recognition": "OCR",
         "expected": [
-            "^下一步$"
+            "^下一步$",
+            "^下一$"
         ],
         "action": "Click",
         "post_wait_freezes": 1000,

--- a/assets/resource/base/pipeline/tasks/AutoSweepBattle.json
+++ b/assets/resource/base/pipeline/tasks/AutoSweepBattle.json
@@ -230,7 +230,8 @@
         "doc": "确认是否为配件自律页面",
         "recognition": "OCR",
         "expected": [
-            "^下一步$"
+            "^下一步$",
+            "^下一$"
         ],
         "roi": [
             645,
@@ -293,7 +294,8 @@
     "selectedEffectsCombinationNextButtonClick": {
         "recognition": "OCR",
         "expected": [
-            "^下一步$"
+            "^下一步$",
+            "^下一$"
         ],
         "roi": [
             645,

--- a/assets/resource/resource_en/pipeline/public/ClaimRewardTasks/passSystem.json
+++ b/assets/resource/resource_en/pipeline/public/ClaimRewardTasks/passSystem.json
@@ -172,7 +172,8 @@
         "recognition": "OCR",
         "expected": [
             "^开启$",
-            "^下一个$"
+            "^下一个$",
+            "^下一$"
         ],
         "action": "Click",
         "post_delay": 2000,


### PR DESCRIPTION
在多个任务的OCR识别中添加「^下一$」作为备选匹配项，以兼容OCR识别不完整的情况：
- passSystem.json: openPassSupplyCrateReward
- 美味烹调.json: 邀请人形-美味烹调
- AutoSweepBattle.json: AutoSweepBattleSupplyOperationPrepareIsAccessories, selectedEffectsCombinationNextButtonClick
- resource_en passSystem.json: openPassSupplyCrateReward