### PR TITLE
fix: 优化休息室任务流程

### DIFF
--- a/assets/resource/base/pipeline/public/PublicAreaDailyTasks/lounge.json
+++ b/assets/resource/base/pipeline/public/PublicAreaDailyTasks/lounge.json
@@ -22,7 +22,6 @@
         ],
         "action": "Click",
         "order_by": "Score",
-        "post_wait_freezes": 1000,
         "next": [
             "loungeConfirm"
         ]
@@ -52,17 +51,20 @@
         "next": [
             "退出整备室"
         ]
-
-    }, 
+    },
     "loungeBackPageNotFound": {
         "next": [
             "clickButtonWithFixedPositionToLeaveDormitory"
         ]
     },
     "clickButtonWithFixedPositionToLeaveDormitory": {
-        "recognition": "DirectHit",
         "action": "Click",
-        "target": [26,23,43,42],
+        "target": [
+            26,
+            23,
+            43,
+            42
+        ],
         "next": [
             "退出整备室"
         ]
@@ -70,10 +72,19 @@
     "退出整备室": {
         "recognition": "TemplateMatch",
         "template": [
-            "公用按钮组件/返回上一页_gray.png",
-            "公用按钮组件/返回上一页_black.png"
+            "公用按钮组件/返回上一页_gray_v2.png",
+            "公用按钮组件/返回上一页_black_v2.png"
         ],
+        "green_mask": true,
         "action": "Click",
+        "next": [
+            "整备室已退出",
+            "退出整备室"
+        ]
+    },
+    "整备室已退出": {
+        "recognition": "OCR",
+        "expected": "战役推进",
         "next": [
             "enterDispatchCenterAction",
             "enterSchedulingGainsAction",


### PR DESCRIPTION
- 移除 loungeButtonClick 中不必要的 post_wait_freezes 参数

- 移除 clickButtonWithFixedPositionToLeaveDormitory 中冗余的 DirectHit 识别

- 更新退出整备室使用的返回按钮模板为 v2 版本

- 添加 green_mask 参数以提升模板匹配准确度

- 新增整备室已退出节点，增加战役推进页面确认

- 格式化代码并修复空行问题