### PR TITLE
fix(集中兑换): 优化家具商店兑换任务流程

### DIFF
--- a/assets/resource/base/pipeline/public/BulkExchangeTasks/enterHomeStoreExchangeTask.json
+++ b/assets/resource/base/pipeline/public/BulkExchangeTasks/enterHomeStoreExchangeTask.json
@@ -19,9 +19,40 @@
         ],
         "post_wait_freezes": 0,
         "next": [
-            "clickHomeStoreExchangeTaskButton",
-            "clickHomeStoreExchangePageButton"
+            "已进入家具商店页面",
+            "clickHomeStoreExchangeTaskButton"
         ]
+    },
+    "已进入家具商店页面": {
+        "recognition": "OCR",
+        "expected": [
+            "当季风潮",
+            "主题空间",
+            "家具模块",
+            "摆设陈列",
+            "墙面装饰"
+        ],
+        "next": [
+            "clickHomeStoreExchangePageButton",
+            "[JumpBack]滑动列表-家具商店"
+        ]
+    },
+    "滑动列表-家具商店": {
+        "max_hit": 1,
+        "action": "Swipe",
+        "begin": [
+            97,
+            491,
+            30,
+            30
+        ],
+        "end": [
+            95,
+            225,
+            32,
+            32
+        ],
+        "end_hold": 1000
     },
     "clickHomeStoreExchangePageButton": {
         "doc": "点击定向调整按钮",


### PR DESCRIPTION
- 新增「已进入家具商店页面」节点，通过OCR识别当季风潮/主题空间等关键词确认页面状态

- 新增「滑动列表-家具商店」节点，支持在家具商店列表中滑动浏览

- 调整任务流程next顺序，优先判断是否已进入商店页面