### PR TITLE
chore(interface): 更新活动名称标记

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -1912,7 +1912,7 @@
                     }
                 },
                 {
-                    "name": "前进吧，王牌配送员!（美服/国际服）",
+                    "name": "前进吧，王牌配送员!(已结束)",
                     "pipeline_override": {
                         "clickVersionActivityTagButton": {
                             "expected": [
@@ -2088,7 +2088,7 @@
                     }
                 },
                 {
-                    "name": "火花之罪·下篇",
+                    "name": "火花之罪·下篇（美服/国际服）",
                     "pipeline_override": {
                         "clickVersionActivityTagButton": {
                             "expected": [


### PR DESCRIPTION
调整活动入口显示名称，补充已结束状态和区服标记，避免活动信息展示混淆。

- 将“前进吧，王牌配送员!”标记为已结束
- 为“火花之罪·下篇”补充美服/国际服标记